### PR TITLE
During phase 1 (`phase == 0`) always take the left side

### DIFF
--- a/mpl_sankey/__init__.py
+++ b/mpl_sankey/__init__.py
@@ -173,8 +173,12 @@ def sankey(data, cmap=plt.get_cmap('jet_r'), flows_color=None,
                 # Draw labels text:
                 if text_x != -1 and labels_color is not None:
                     if node_sizes is not False:
-                        size = (r_sizes.iloc[idx] if phase
-                                else l_sizes.iloc[idx])
+                        if phase == 0 and pos == 'right':
+                            size = r_sizes.iloc[idx]
+                        elif phase:
+                            size = r_sizes.iloc[idx]
+                        else:
+                            size = l_sizes.iloc[idx]
                         text = _node_text(start, size, node_sizes)
                     else:
                         text = f"{start}"


### PR DESCRIPTION
otherwise, if phase 2 (`phase==1`) has more nodes than phase 1 (`phase==0`) than you're going to try and access a right-side size for an index that doesnt exist

fixes #4